### PR TITLE
Local_MCO_UEM

### DIFF
--- a/truezip-maven-plugin/pom.xml
+++ b/truezip-maven-plugin/pom.xml
@@ -29,6 +29,7 @@
   </parent>
 
   <artifactId>truezip-maven-plugin</artifactId>
+  <version>1.2-uem</version>
   <name>TrueZIP Maven Plugin</name>
 
   <packaging>maven-plugin</packaging>
@@ -44,6 +45,7 @@
     <dependency>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>truezip-utils</artifactId>
+      <version>1.1</version>
     </dependency>
 
     <dependency>

--- a/truezip-maven-plugin/pom.xml
+++ b/truezip-maven-plugin/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>truezip-maven-plugin</artifactId>
-  <version>1.2-uem</version>
   <name>TrueZIP Maven Plugin</name>
 
   <packaging>maven-plugin</packaging>
@@ -45,7 +44,6 @@
     <dependency>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>truezip-utils</artifactId>
-      <version>1.1</version>
     </dependency>
 
     <dependency>

--- a/truezip-maven-plugin/src/main/java/org/codehaus/mojo/truezip/AbstractArchiveMojo.java
+++ b/truezip-maven-plugin/src/main/java/org/codehaus/mojo/truezip/AbstractArchiveMojo.java
@@ -59,6 +59,15 @@ public abstract class AbstractArchiveMojo
     protected boolean immediateUpdate;
 
     /**
+    * If any file is not present during the execution of this plugin, the build will fail if this parameter is true (default)
+    * or will not fail ih this parameter is false
+    * 
+    * @parameter default-value="true"
+    * @since 1.2 beta-1
+    */
+    protected boolean failIfFileNoPresent;
+    
+    /**
      * Skip
      * 
      * @parameter property="truezip.skip" default-value="false"

--- a/truezip-maven-plugin/src/main/java/org/codehaus/mojo/truezip/CliCopyMojo.java
+++ b/truezip-maven-plugin/src/main/java/org/codehaus/mojo/truezip/CliCopyMojo.java
@@ -82,7 +82,10 @@ public class CliCopyMojo
         }
         catch ( IOException e )
         {
-            throw new MojoExecutionException( "Unable to copy: " + from + " to " + to, e );
+          if (failIfFileNoPresent){
+            throw new MojoExecutionException( "Unable to copy: " + from + " to " + to,  e );
+          }
+          getLog().debug(new MojoExecutionException( "Unable to copy: " + from + " to " + to,  e ));
         }
 
         this.tryImmediateUpdate();


### PR DESCRIPTION
Problème rencontré :
Si un fichier n'existe pas lors de sa copie, alors le build Maven sort en erreur. On a des cas ou l'on voudrait pouvoir copier un fichier s'il existe, mais ne rien faire sinon (et donc ne pas sortir en erreur).
