### PR TITLE
Bump truezip to 7.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
   </prerequisites>
 
   <properties>
-    <truezip.version>7.7.9</truezip.version>
+    <truezip.version>7.7.10</truezip.version>
     <maven.version>2.2.1</maven.version>
     <mojo.java.target>1.6</mojo.java.target>
     <scmpublish.content>${project.build.directory}/staging/truezip</scmpublish.content>


### PR DESCRIPTION
Truezip 7.7.5, used in the 1.2 release, doesn't see some files included in .tar.gz archives. I've overridden it in builds by adding this to the `<plugin>` configuration:

```
        <dependencies>
          <dependency>
            <groupId>de.schlichtherle.truezip</groupId>
            <artifactId>truezip-driver-tar</artifactId>
            <version>7.7.10</version>
          </dependency>
        </dependencies>
```